### PR TITLE
Add OpenCode and Pi benchmark harnesses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # For openhands agent (via OpenRouter)
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 
+# For DeepSeek models in Pi (and OpenCode when configured with DeepSeek directly)
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+
+# For OpenCode Zen/OpenCode Go models
+OPENCODE_API_KEY=your_opencode_api_key_here
+
 # For openhands agent (via Fireworks)
 FIREWORKS_API_KEY=your_fireworks_api_key_here
 

--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,4 @@ tasks/task_*/
 tasks_gt/task_*/
 .archiver_shadow/
 .snapshots/
+.benchmark-config/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Install the agent(s) you want to use:
 - **Codex** — [Codex](https://openai.com/codex/)
 - **Gemini CLI** — [Gemini CLI](https://geminicli.com/)
 - **OpenHands** — [OpenHands](https://www.openhands.dev/)
+- **OpenCode** — [OpenCode](https://opencode.ai/)
+- **Pi** — [Pi coding agent](https://github.com/badlogic/pi-mono)
 
 #### Setup Tasks
 
@@ -80,6 +82,33 @@ uv run python gamedevbench/src/benchmark_runner.py \
 | `codex` | OpenAI Codex |
 | `gemini-cli` | Google Gemini CLI |
 | `openhands` | OpenHands (requires Python 3.12+) |
+| `opencode` | OpenCode CLI, using its default agent prompt and tools |
+| `omo` | Oh My OpenAgent's Sisyphus orchestrator in an isolated OpenCode config |
+| `pi` | Pi coding agent, using its default prompt, tools, and extensions |
+| `pi-stock` | Pi with an isolated config that omits the user's `SYSTEM.md` |
+
+OpenCode and Pi use different provider-qualified model names. For example, the
+same DeepSeek V4 Flash model may be selected as
+`opencode-go/deepseek-v4-flash` in OpenCode and
+`deepseek/deepseek-v4-flash` in Pi. Verify the available names with
+`opencode models` and `pi --list-models deepseek` before a run.
+
+#### Isolated Pi and OMO Variants
+
+Prepare both isolated configurations without modifying the user's normal Pi or
+OpenCode configuration:
+
+```powershell
+.\prepare_benchmark_variants.ps1
+```
+
+The OMO configuration pins `oh-my-openagent@4.10.0`, disables model fallback,
+and maps all built-in agents and categories to
+`opencode-go/deepseek-v4-flash`. Run the paired 24-task comparison with:
+
+```powershell
+.\run_benchmark_variants.ps1
+```
 
 #### Command-Line Options
 
@@ -105,6 +134,40 @@ Benchmark results are saved to `results/` directory with the following informati
 - Token usage and costs
 - Execution time
 - Validation results
+- Environment metadata, including agent CLI, Godot, Python, and repository versions
+
+### Local 24-Task Agent Harness Comparison
+
+The following local comparison used the same fixed 24-task subset,
+`benchmark_24.yaml`, across agent harnesses. Each run used the normal
+GameDevBench validation loop in Godot 4.6.2 and recorded token/cost data from
+the agent harness output. Runs were kept in separate result directories and
+were not merged with the upstream benchmark leaderboard.
+
+Unless noted otherwise, reasoning was configured through the corresponding
+agent's normal settings rather than explicit benchmark CLI flags. Claude Code
+was run with high effort; OpenCode and OMO were run with medium effort; Pi
+runs used high thinking from Pi's `defaultThinkingLevel`; the Codex baseline
+used the configured default model with medium reasoning.
+
+| Run | Agent / Harness | Model or routing | Reasoning | Passed | Success rate | Tokens | Cost | Notes |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| DeepSeek V4 Pro practical | Claude Code | `deepseek-v4-pro` with configured Claude Code sub-model routing | High | 11 / 24 | 45.83% | 3,361,199 | $0.5635 | Claude Code routed most recorded task calls to the configured fast sub-model, which affects the cost comparison. |
+| DeepSeek V4 Pro practical | OpenCode | `opencode-go/deepseek-v4-pro` | Medium | 8 / 24 | 33.33% | 654,711 | $1.4755 | Standard OpenCode harness. |
+| DeepSeek V4 Pro practical | Pi | `deepseek/deepseek-v4-pro` | High | 9 / 24 | 37.50% | 440,759 | $1.0659 | Pi run using the user's replacement system prompt. |
+| DeepSeek V4 Pro practical | Pi stock | `deepseek/deepseek-v4-pro` | High | 7 / 24 | 29.17% | 401,934 | $1.0565 | Isolated Pi config without the user's replacement system prompt; one runner error was recorded. |
+| DeepSeek V4 Pro practical | OMO | Mixed `deepseek-v4-pro` / `deepseek-v4-flash` role routing | Medium | 6 / 24 | 25.00% | 1,190,474 | $2.4842 | Practical mixed setup: orchestration and high-impact roles used Pro, lightweight/support roles used Flash. |
+| Codex baseline | Codex | Configured default `gpt-5.5` | Medium | 14 / 24 | 58.33% | 4,584,125 | $14.7274 | Run without an explicit `--model`; cost uses local runner pricing metadata and may not match actual billing. |
+| Pi GLM-5.2 | Pi | `opencode_go/glm-5.2` | High | 8 / 24 | 33.33% | 379,584 | $2.2055 | Three connection-error tasks were rerun and merged into the run; six zero-token timeout/error tasks remained. |
+| Pi Qwen3.7 Max | Pi | `opencode_go/qwen3.7-max` | High | 11 / 24 | 45.83% | 765,477 | $3.7130 | One runner error (`task_0109`) was recorded. |
+
+The 24-task subset used for these local runs was:
+
+`task_0001`, `task_0007`, `task_0012`, `task_0018`, `task_0024`,
+`task_0029`, `task_0035`, `task_0041`, `task_0047`, `task_0052`,
+`task_0058`, `task_0064`, `task_0069`, `task_0075`, `task_0081`,
+`task_0086`, `task_0092`, `task_0098`, `task_0104`, `task_0109`,
+`task_0115`, `task_0121`, `task_0126`, and `task_0132`.
 
 ## Citation
 

--- a/benchmark_24.yaml
+++ b/benchmark_24.yaml
@@ -1,0 +1,25 @@
+tasks:
+- task_0001
+- task_0007
+- task_0012
+- task_0018
+- task_0024
+- task_0029
+- task_0035
+- task_0041
+- task_0047
+- task_0052
+- task_0058
+- task_0064
+- task_0069
+- task_0075
+- task_0081
+- task_0086
+- task_0092
+- task_0098
+- task_0104
+- task_0109
+- task_0115
+- task_0121
+- task_0126
+- task_0132

--- a/benchmark_configs/omo_deepseek_v4_flash.jsonc
+++ b/benchmark_configs/omo_deepseek_v4_flash.jsonc
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json",
+  "runtime_fallback": false,
+  "agents": {
+    "sisyphus": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "hephaestus": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "prometheus": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "oracle": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "librarian": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "explore": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "multimodal-looker": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "metis": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "momus": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "atlas": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "sisyphus-junior": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] }
+  },
+  "categories": {
+    "visual-engineering": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "ultrabrain": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "deep": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "artistry": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "quick": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "unspecified-low": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "unspecified-high": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "writing": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] }
+  }
+}

--- a/benchmark_configs/omo_deepseek_v4_pro_practical.jsonc
+++ b/benchmark_configs/omo_deepseek_v4_pro_practical.jsonc
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json",
+  "runtime_fallback": false,
+  "agents": {
+    "sisyphus": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "hephaestus": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "prometheus": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "metis": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "momus": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "atlas": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "oracle": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "librarian": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "explore": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "multimodal-looker": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "sisyphus-junior": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] }
+  },
+  "categories": {
+    "visual-engineering": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "ultrabrain": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "deep": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "artistry": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "unspecified-high": { "model": "opencode-go/deepseek-v4-pro", "fallback_models": [] },
+    "quick": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "unspecified-low": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] },
+    "writing": { "model": "opencode-go/deepseek-v4-flash", "fallback_models": [] }
+  }
+}

--- a/benchmark_configs/omo_opencode.json
+++ b/benchmark_configs/omo_opencode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "oh-my-openagent@4.10.0"
+  ]
+}

--- a/gamedevbench/src/benchmark_runner.py
+++ b/gamedevbench/src/benchmark_runner.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import shutil
 import csv
+import sys
 import yaml
 import tempfile
 import uuid
@@ -23,8 +24,59 @@ from gamedevbench.src.utils.constants import (
     TIMEOUT,
 )
 from gamedevbench.src.utils.data_types import ValidationResult
+from gamedevbench.src.utils.environment import collect_environment_metadata
 from gamedevbench.src.utils.validation import ValidationParser
 from gamedevbench.src.solver_factory import SolverFactory
+
+MAX_TRAJECTORY_STREAM_CHARS = 5_000_000
+
+
+def _configure_utf8_stdio():
+    """Use UTF-8 for redirected Windows output without failing on bad characters."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
+def _write_solver_trajectory(
+    log_file_path: Path,
+    task_name: str,
+    agent: str,
+    display_model: Optional[str],
+    sandbox_dir: Path,
+    solver_result,
+):
+    """Persist a solver trajectory without relying on the platform encoding."""
+    with open(log_file_path, "w", encoding="utf-8", errors="replace") as f:
+        f.write(f"Task: {task_name}\n")
+        f.write(f"Agent: {agent}\n")
+        f.write(f"Model: {display_model}\n")
+        f.write(f"Sandbox: {sandbox_dir}\n")
+        f.write(f"Timestamp: {datetime.now().isoformat()}\n")
+        f.write("=" * 80 + "\n\n")
+        if solver_result:
+            f.write(f"Success: {solver_result.success}\n")
+            f.write(f"Message: {solver_result.message}\n")
+            f.write(f"Duration: {solver_result.duration_seconds:.2f}s\n\n")
+            f.write("STDOUT:\n")
+            f.write(_bounded_trajectory_text(solver_result.stdout or ""))
+            f.write("\n\nSTDERR:\n")
+            f.write(_bounded_trajectory_text(solver_result.stderr or ""))
+
+
+def _bounded_trajectory_text(text: str) -> str:
+    """Keep trajectory logs useful without persisting huge cumulative JSON streams."""
+    if len(text) <= MAX_TRAJECTORY_STREAM_CHARS:
+        return text
+
+    half = MAX_TRAJECTORY_STREAM_CHARS // 2
+    omitted = len(text) - (half * 2)
+    return (
+        text[:half]
+        + f"\n\n... omitted {omitted} characters from oversized trajectory ...\n\n"
+        + text[-half:]
+    )
 
 
 class GodotBenchmarkRunner:
@@ -70,6 +122,7 @@ class GodotBenchmarkRunner:
         self.resume_from = resume_from
         self.skip_display = skip_display
         self.use_runtime_video = use_runtime_video
+        self.environment_metadata = collect_environment_metadata(self.agent)
 
         # Validate agent configuration early if agent is specified
         if self.agent:
@@ -130,7 +183,7 @@ class GodotBenchmarkRunner:
             "results": results,
             "timestamp": datetime.now().isoformat(),
         }
-        with open(self.progress_file, "w") as f:
+        with open(self.progress_file, "w", encoding="utf-8") as f:
             json.dump(progress_data, f, indent=2)
         if self.debug:
             print(f"Progress saved to: {self.progress_file}")
@@ -141,7 +194,7 @@ class GodotBenchmarkRunner:
             return [], []
 
         try:
-            with open(self.progress_file, "r") as f:
+            with open(self.progress_file, "r", encoding="utf-8") as f:
                 progress_data = json.load(f)
             completed_tasks = progress_data.get("completed_tasks", [])
             results = progress_data.get("results", [])
@@ -173,7 +226,7 @@ class GodotBenchmarkRunner:
             return [], [], []
 
         try:
-            with open(results_path, "r") as f:
+            with open(results_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
 
             tasks_to_skip = []
@@ -216,7 +269,7 @@ class GodotBenchmarkRunner:
         config_path = self.tasks_dir / task_name / "task_config.json"
 
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 return json.load(f)
         except Exception as e:
             print(f"Error loading config for task {task_name}: {e}")
@@ -271,7 +324,7 @@ class GodotBenchmarkRunner:
                 print(f"Main scene not found: {main_scene_path}")
                 return False
 
-            with open(main_scene_path, "r") as f:
+            with open(main_scene_path, "r", encoding="utf-8", errors="replace") as f:
                 main_content = f.read()
 
             # Create validation scene content by adding test node
@@ -318,7 +371,7 @@ script = ExtResource("test_script")
 
             # Write the validation scene
             validation_scene_path = task_dir / "scenes" / "validation_scene.tscn"
-            with open(validation_scene_path, "w") as f:
+            with open(validation_scene_path, "w", encoding="utf-8") as f:
                 f.write(validation_content)
 
             return True
@@ -368,7 +421,12 @@ script = ExtResource("test_script")
 
             try:
                 subprocess_result = subprocess.run(
-                    cmd, capture_output=True, text=True, timeout=3
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=3,
                 )
                 # TODO Move this to a script that sets up the entire repo
                 print("Loading editor to ensure project files are fully loaded")
@@ -390,7 +448,12 @@ script = ExtResource("test_script")
             mode_str = "headless mode" if use_headless else "display mode"
             print(f"Running validation for task: {task_name} ({mode_str})")
             subprocess_result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=TIMEOUT
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=TIMEOUT,
             )
 
             # Parse the output for test results
@@ -556,7 +619,7 @@ script = ExtResource("test_script")
         task_config_src = task_dir / "task_config.json"
         if task_config_src.exists():
             try:
-                with open(task_config_src, "r") as f:
+                with open(task_config_src, "r", encoding="utf-8") as f:
                     full_config = json.load(f)
                 # Only include instruction field - nothing else that could help cheat
                 minimal_config = {
@@ -564,7 +627,7 @@ script = ExtResource("test_script")
                         "instruction", "No instruction provided"
                     )
                 }
-                with open(sandbox_dir / "task_config.json", "w") as f:
+                with open(sandbox_dir / "task_config.json", "w", encoding="utf-8") as f:
                     json.dump(minimal_config, f, indent=2)
             except Exception as e:
                 if self.debug:
@@ -651,7 +714,14 @@ script = ExtResource("test_script")
                 cmd.insert(1, "--headless")
 
             try:
-                subprocess.run(cmd, capture_output=True, text=True, timeout=3)
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=3,
+                )
                 if self.debug:
                     print(
                         "      Loading editor to ensure project files are fully loaded"
@@ -677,7 +747,12 @@ script = ExtResource("test_script")
                 print(f"      Running validation in: {validation_dir} ({mode_str})")
 
             result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=TIMEOUT
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=TIMEOUT,
             )
             output = result.stdout + result.stderr
             validation_result = ValidationParser.parse_output(output, debug=self.debug)
@@ -754,7 +829,7 @@ script = ExtResource("test_script")
 
             # Write to result.json
             result_json_path = result_subdir / "result.json"
-            with open(result_json_path, "w") as f:
+            with open(result_json_path, "w", encoding="utf-8") as f:
                 json.dump(result_json, f, indent=2)
 
         return result_subdir
@@ -815,7 +890,14 @@ script = ExtResource("test_script")
                     "--path",
                     str(sandbox_dir),
                 ]
-                subprocess.run(cmd, capture_output=True, text=True, timeout=3)
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=3,
+                )
                 if self.debug:
                     print("      Assets loaded and imported")
             except subprocess.TimeoutExpired:
@@ -846,22 +928,18 @@ script = ExtResource("test_script")
                 )
                 solver_result = solver.solve_task()
 
-                # Save solver output to log file
-                with open(log_file_path, "w") as f:
-                    f.write(f"Task: {task_name}\n")
-                    f.write(f"Agent: {self.agent}\n")
-                    f.write(f"Model: {display_model}\n")
-                    f.write(f"Sandbox: {sandbox_dir}\n")
-                    f.write(f"Timestamp: {datetime.now().isoformat()}\n")
-                    f.write("=" * 80 + "\n\n")
-                    if solver_result:
-                        f.write(f"Success: {solver_result.success}\n")
-                        f.write(f"Message: {solver_result.message}\n")
-                        f.write(f"Duration: {solver_result.duration_seconds:.2f}s\n\n")
-                        f.write("STDOUT:\n")
-                        f.write(solver_result.stdout or "")
-                        f.write("\n\nSTDERR:\n")
-                        f.write(solver_result.stderr or "")
+                # Logging failures must not discard a completed solver result.
+                try:
+                    _write_solver_trajectory(
+                        log_file_path,
+                        task_name,
+                        self.agent,
+                        display_model,
+                        sandbox_dir,
+                        solver_result,
+                    )
+                except Exception as log_error:
+                    print(f"Warning: Could not save solver trajectory: {log_error}")
 
                 if self.debug:
                     print(
@@ -934,7 +1012,11 @@ script = ExtResource("test_script")
                 "message": validation_result.message,
                 "timestamp": validation_result.timestamp,
                 "agent": self.agent,
-                "model": display_model,
+                "model": (
+                    solver_result.model
+                    if solver_result and solver_result.model
+                    else display_model
+                ),
                 "use_mcp": self.use_mcp,
                 "use_runtime_video": self.use_runtime_video,
                 "skip_display": self.skip_display,
@@ -1001,14 +1083,14 @@ script = ExtResource("test_script")
         # Save final results to JSON
         RESULTS_FOLDER.mkdir(exist_ok=True)
         final_results_path = RESULTS_FOLDER / "final_results.json"
-        with open(final_results_path, "w") as f:
+        with open(final_results_path, "w", encoding="utf-8") as f:
             json.dump(final_results, f, indent=2)
 
         # Also save to agent-model-specific file if agent is specified
         if self.agent:
             safe_model = self.model.replace("/", "_") if self.model else "default"
             agent_model_results_path = RESULTS_FOLDER / f"{self.agent}_{safe_model}_final_results.json"
-            with open(agent_model_results_path, "w") as f:
+            with open(agent_model_results_path, "w", encoding="utf-8") as f:
                 json.dump(final_results, f, indent=2)
 
         # Save results to CSV
@@ -1213,14 +1295,14 @@ script = ExtResource("test_script")
         # Save final results to JSON
         RESULTS_FOLDER.mkdir(exist_ok=True)
         final_results_path = RESULTS_FOLDER / "final_results.json"
-        with open(final_results_path, "w") as f:
+        with open(final_results_path, "w", encoding="utf-8") as f:
             json.dump(final_results, f, indent=2)
 
         # Also save to agent-model-specific file if agent is specified
         if self.agent:
             safe_model = self.model.replace("/", "_") if self.model else "default"
             agent_model_results_path = RESULTS_FOLDER / f"{self.agent}_{safe_model}_final_results.json"
-            with open(agent_model_results_path, "w") as f:
+            with open(agent_model_results_path, "w", encoding="utf-8") as f:
                 json.dump(final_results, f, indent=2)
 
         # Save results to CSV
@@ -1313,6 +1395,7 @@ script = ExtResource("test_script")
                 "skip_display": self.skip_display,
                 "debug": self.debug,
             },
+            "environment": self.environment_metadata,
             # Token usage statistics
             "token_statistics": {
                 "total_input_tokens": total_input_tokens,
@@ -1365,7 +1448,7 @@ script = ExtResource("test_script")
             "result_dir",
         ]
 
-        with open(csv_path, "w", newline="") as csvfile:
+        with open(csv_path, "w", newline="", encoding="utf-8") as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
 
@@ -1397,6 +1480,7 @@ script = ExtResource("test_script")
 
 
 def main():
+    _configure_utf8_stdio()
     parser = argparse.ArgumentParser(description="Godot Benchmark Runner")
     parser.add_argument("--gt", help="Use GT tasks directory", action="store_true")
     parser.add_argument(
@@ -1406,8 +1490,8 @@ def main():
     )
     parser.add_argument(
         "--model",
-        default="claude",
-        help="Model to use (for claude-code: model name; for mini-swe: 'claude' or 'gpt'; for openhands: model name like 'gpt-4o'; for gemini-cli: model name like 'gemini-2.0-flash'; ignored for codex)",
+        default=None,
+        help="Agent-specific model name (for example: opencode-go/deepseek-v4-flash for OpenCode or deepseek/deepseek-v4-flash for Pi)",
     )
     parser.add_argument("--debug", help="Show debug output", action="store_true")
     parser.add_argument(

--- a/gamedevbench/src/codex_solver.py
+++ b/gamedevbench/src/codex_solver.py
@@ -8,6 +8,7 @@ import json
 import time
 import os
 import subprocess
+import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -61,7 +62,7 @@ args = ["run", "gamedevbench-mcp"]
             content = config_file.read_text()
             if "godot-screenshot" not in content:
                 # Append MCP config
-                with open(config_file, 'a') as f:
+                with open(config_file, 'a', encoding='utf-8') as f:
                     f.write("\n" + mcp_config)
                 if self.debug:
                     print(f"Added godot-screenshot MCP config to {config_file}")
@@ -92,7 +93,14 @@ args = ["run", "gamedevbench-mcp"]
             )
 
         start_time = time.time()
-        prompt = self.get_task_prompt(config)
+        prompt = (
+            "重要：本 benchmark 的用户已经明确确认可以实施。"
+            "“先说明方案、等用户确认”的要求已经在启动本次 benchmark 前满足。"
+            "你现在必须直接修改文件并完成任务；不要输出方案后停下，不要请求确认。\n\n"
+            + self.get_task_prompt(config)
+            + "\nThe user has already approved implementation for this benchmark task. "
+            + "Apply the required changes now; do not stop to ask for confirmation."
+        )
 
         if self.debug:
             print("=" * 60)
@@ -102,13 +110,21 @@ args = ["run", "gamedevbench-mcp"]
             print("=" * 60)
 
         try:
+            executable = shutil.which("codex")
+            if not executable:
+                return SolverResult(
+                    success=False,
+                    message="Codex CLI not found. Install with: npm i -g @openai/codex",
+                    duration_seconds=0.0,
+                )
+
             # Build codex exec command
             cmd = [
-                "codex",
-                "--model", 
-                self.model,
+                executable,
                 "exec",
                 "--skip-git-repo-check",
+                "--ignore-rules",
+                "--json",
                 "--yolo",
                 "-s", 
                 "danger-full-access",
@@ -116,6 +132,8 @@ args = ["run", "gamedevbench-mcp"]
                 str(os.getcwd()),
                 prompt,
             ]
+            if self.model:
+                cmd[1:1] = ["--model", self.model]
 
             if self.debug:
                 cmd_str = " ".join([c if " " not in c else f'"{c}"' for c in cmd[:-1]])
@@ -128,6 +146,8 @@ args = ["run", "gamedevbench-mcp"]
                 cmd,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=self.timeout_seconds,
                 cwd=os.getcwd(),
             )
@@ -148,7 +168,7 @@ args = ["run", "gamedevbench-mcp"]
             # Parse final response and token usage
             final_response = self._parse_final_response(stdout)
             token_usage = self._parse_token_usage(stdout)
-            model_used = self.model
+            model_used = self.model or "codex-default"
 
             # Calculate cost
             cost_usd = 0.0

--- a/gamedevbench/src/omo_solver.py
+++ b/gamedevbench/src/omo_solver.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Oh My OpenAgent solver using an isolated OpenCode configuration."""
+
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from gamedevbench.src.opencode_solver import OpenCodeSolver
+from gamedevbench.src.utils.constants import PROJECT_ROOT
+from gamedevbench.src.utils.data_types import SolverResult, TokenUsage
+from gamedevbench.src.utils.processes import run_cli_command
+
+
+DEFAULT_XDG_CONFIG_HOME = PROJECT_ROOT / ".benchmark-config" / "omo"
+
+
+class OmoSolver(OpenCodeSolver):
+    """Run OMO's Sisyphus orchestrator without touching the user's OpenCode config."""
+
+    def solve_task(self) -> SolverResult:
+        config_dir = self._xdg_config_home() / "opencode"
+        if not (config_dir / "opencode.json").is_file():
+            return SolverResult(False, f"OMO config is not prepared: {config_dir}", 0.0)
+        if not any(
+            (config_dir / name).is_file()
+            for name in ("oh-my-openagent.jsonc", "oh-my-opencode.jsonc")
+        ):
+            return SolverResult(False, f"OMO model config is missing: {config_dir}", 0.0)
+        result = super().solve_task()
+        if "not found. Falling back to default agent" in (result.stderr or ""):
+            result.success = False
+            result.message = "OMO primary agent was not found; OpenCode used its default agent"
+        self._add_subagent_usage(result)
+        return result
+
+    def _xdg_config_home(self) -> Path:
+        override = os.environ.get("GAMEDEVBENCH_OMO_XDG_CONFIG_HOME")
+        return Path(override) if override else DEFAULT_XDG_CONFIG_HOME
+
+    def _agent_name(self) -> Optional[str]:
+        return "Sisyphus - ultraworker"
+
+    def _command_environment(self) -> Optional[dict[str, str]]:
+        xdg_config_home = self._xdg_config_home()
+        env = os.environ.copy()
+        env["XDG_CONFIG_HOME"] = str(xdg_config_home)
+        env["OPENCODE_CONFIG_DIR"] = str(xdg_config_home / "opencode")
+        env["OMO_SEND_ANONYMOUS_TELEMETRY"] = "0"
+        env["OMO_DISABLE_POSTHOG"] = "1"
+        env["OPENCODE_DISABLE_CLAUDE_CODE"] = "true"
+        env["OPENCODE_DISABLE_CLAUDE_CODE_PROMPT"] = "true"
+        env["OPENCODE_DISABLE_CLAUDE_CODE_SKILLS"] = "true"
+        return env
+
+    def _add_subagent_usage(self, result: SolverResult) -> None:
+        session_ids = self._subagent_session_ids(result.stdout)
+        executable = shutil.which("opencode")
+        if not session_ids or not executable:
+            return
+
+        aggregate = result.token_usage or TokenUsage()
+        for session_id in session_ids:
+            try:
+                exported = run_cli_command(
+                    [executable, "export", session_id],
+                    timeout_seconds=30,
+                    cwd=os.getcwd(),
+                    env=self._command_environment(),
+                )
+            except Exception:
+                continue
+            usage = self._parse_exported_usage(exported.stdout)
+            if not usage:
+                continue
+            aggregate.input_tokens += usage.input_tokens
+            aggregate.output_tokens += usage.output_tokens
+            aggregate.total_tokens += usage.total_tokens
+            aggregate.cache_read_tokens += usage.cache_read_tokens
+            aggregate.cache_write_tokens += usage.cache_write_tokens
+
+        result.token_usage = aggregate
+        result.calculate_cost()
+
+    @staticmethod
+    def _subagent_session_ids(output: str) -> set[str]:
+        session_ids = set()
+        for line in output.splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            part = event.get("part", {})
+            if event.get("type") != "tool_use" or part.get("tool") not in {
+                "task",
+                "call_omo_agent",
+            }:
+                continue
+            metadata = part.get("state", {}).get("metadata", {})
+            session_id = metadata.get("sessionId") or metadata.get("taskId")
+            if session_id:
+                session_ids.add(session_id)
+        return session_ids
+
+    @staticmethod
+    def _parse_exported_usage(output: str) -> Optional[TokenUsage]:
+        try:
+            payload = json.loads(output)
+        except json.JSONDecodeError:
+            return None
+        tokens = payload.get("info", {}).get("tokens", {})
+        input_tokens = tokens.get("input", 0) or 0
+        output_tokens = (tokens.get("output", 0) or 0) + (
+            tokens.get("reasoning", 0) or 0
+        )
+        cache = tokens.get("cache", {})
+        if not input_tokens and not output_tokens:
+            return None
+        return TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+            cache_read_tokens=cache.get("read", 0) or 0,
+            cache_write_tokens=cache.get("write", 0) or 0,
+        )

--- a/gamedevbench/src/opencode_solver.py
+++ b/gamedevbench/src/opencode_solver.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Claude Code CLI solver for GameDevBench tasks."""
+"""OpenCode CLI solver for GameDevBench tasks."""
 
 import json
 import os
@@ -13,21 +13,20 @@ from gamedevbench.src.utils.data_types import SolverResult, TokenUsage
 from gamedevbench.src.utils.processes import run_cli_command
 
 
-class ClaudeCodeSolver(BaseSolver):
-    """Run tasks through Claude Code while preserving its default prompt and tools."""
+class OpenCodeSolver(BaseSolver):
+    """Run tasks through OpenCode while preserving its default agent and tools."""
 
-    SUPPORTS_MCP = True
+    SUPPORTS_MCP = False
     SUPPORTS_SYSTEM_PROMPT = False
 
     def __init__(
         self,
         timeout_seconds: int = 600,
         debug: bool = False,
-        use_mcp: bool = False,
-        use_runtime_video: bool = False,
         model: Optional[str] = None,
+        use_runtime_video: bool = False,
     ):
-        super().__init__(timeout_seconds, debug, use_mcp, use_runtime_video)
+        super().__init__(timeout_seconds, debug, False, use_runtime_video)
         self.model = model
 
     @staticmethod
@@ -36,14 +35,11 @@ class ClaudeCodeSolver(BaseSolver):
         return any(
             keyword in error_lower
             for keyword in (
-                "overloaded",
                 "rate limit",
                 "rate_limit",
                 "quota exceeded",
                 "too many requests",
                 "429",
-                "capacity",
-                "usage limit",
             )
         )
 
@@ -52,36 +48,29 @@ class ClaudeCodeSolver(BaseSolver):
         if not config:
             return SolverResult(False, "Could not load task configuration", 0.0)
 
-        executable = shutil.which("claude")
+        prompt = self.get_task_prompt(config)
+        executable = shutil.which("opencode")
         if not executable:
             return SolverResult(
                 False,
-                "Claude Code CLI not found. Install from: https://code.claude.com/",
+                "OpenCode CLI not found. Install from: https://opencode.ai/docs/",
                 0.0,
             )
 
-        prompt = self.get_task_prompt(config)
         cmd = [
             executable,
-            "--print",
-            "--output-format",
-            "stream-json",
-            "--verbose",
+            "run",
+            "--format",
+            "json",
             "--dangerously-skip-permissions",
-            "--no-session-persistence",
+            "--dir",
+            os.getcwd(),
         ]
         if self.model:
             cmd.extend(["--model", self.model])
-        if self.use_mcp:
-            mcp_config = {
-                "mcpServers": {
-                    "godot-screenshot": {
-                        "command": "uv",
-                        "args": ["run", "gamedevbench-mcp"],
-                    }
-                }
-            }
-            cmd.extend(["--mcp-config", json.dumps(mcp_config)])
+        agent = self._agent_name()
+        if agent:
+            cmd.extend(["--agent", agent])
         cmd.append(prompt)
 
         start_time = time.time()
@@ -90,12 +79,13 @@ class ClaudeCodeSolver(BaseSolver):
                 cmd,
                 timeout_seconds=self.timeout_seconds,
                 cwd=os.getcwd(),
+                env=self._command_environment(),
             )
             duration = time.time() - start_time
             parsed = self._parse_output(result.stdout)
             error_message = parsed["error"]
             success = result.returncode == 0 and not error_message
-            model_used = parsed["model"] or self.model or "claude-code-default"
+            model_used = parsed["model"] or self.model or "opencode-default"
             token_usage = parsed["token_usage"]
             cost_usd = token_usage.calculate_cost(model_used) if token_usage else 0.0
 
@@ -103,13 +93,14 @@ class ClaudeCodeSolver(BaseSolver):
                 message = parsed["response"] or "Task completed"
             else:
                 details = error_message or result.stderr.strip()
-                message = f"Claude Code CLI failed (exit code {result.returncode})"
+                message = f"OpenCode CLI failed (exit code {result.returncode})"
                 if details:
                     message += f": {details}"
 
             combined_error = "\n".join(
                 part for part in (error_message, result.stderr) if part
             )
+
             if self.debug:
                 print(result.stdout)
                 if result.stderr:
@@ -129,30 +120,39 @@ class ClaudeCodeSolver(BaseSolver):
         except subprocess.TimeoutExpired:
             return SolverResult(
                 False,
-                f"Claude Code CLI timed out after {self.timeout_seconds}s",
+                f"OpenCode CLI timed out after {self.timeout_seconds}s",
                 time.time() - start_time,
             )
         except FileNotFoundError:
             return SolverResult(
                 False,
-                "Claude Code CLI not found. Install from: https://code.claude.com/",
+                "OpenCode CLI not found. Install from: https://opencode.ai/docs/",
                 0.0,
             )
         except Exception as exc:
             error_message = str(exc)
             return SolverResult(
                 False,
-                f"Error invoking Claude Code: {error_message}",
+                f"Error invoking OpenCode: {error_message}",
                 time.time() - start_time,
                 is_rate_limited=self.is_rate_limit_error(error_message),
             )
 
+    def _agent_name(self) -> Optional[str]:
+        return None
+
+    def _command_environment(self) -> Optional[dict[str, str]]:
+        return None
+
     @staticmethod
     def _parse_output(output: str) -> dict:
-        response = ""
-        error_message = ""
+        input_tokens = 0
+        output_tokens = 0
+        cache_read_tokens = 0
+        cache_write_tokens = 0
         model = ""
-        token_usage = None
+        response_parts = []
+        error_message = ""
 
         for line in output.splitlines():
             try:
@@ -160,30 +160,43 @@ class ClaudeCodeSolver(BaseSolver):
             except json.JSONDecodeError:
                 continue
 
-            if event.get("type") == "assistant":
-                message = event.get("message", {})
-                model = message.get("model") or model
-            elif event.get("type") == "result":
-                response = event.get("result") or response
-                if event.get("is_error") or event.get("subtype") != "success":
-                    error_message = response or event.get("subtype", "Claude Code error")
+            event_type = event.get("type")
+            part = event.get("part", {})
+            model = (
+                event.get("modelID")
+                or event.get("model")
+                or part.get("modelID")
+                or part.get("model")
+                or model
+            )
+            if event_type == "text" and part.get("text"):
+                response_parts.append(part["text"])
+            elif event_type == "step_finish":
+                tokens = part.get("tokens", {})
+                cache = tokens.get("cache", {})
+                input_tokens += tokens.get("input", 0) or 0
+                output_tokens += (tokens.get("output", 0) or 0) + (
+                    tokens.get("reasoning", 0) or 0
+                )
+                cache_read_tokens += cache.get("read", 0) or 0
+                cache_write_tokens += cache.get("write", 0) or 0
+            elif event_type == "error":
+                error = event.get("error", {})
+                data = error.get("data", {}) if isinstance(error, dict) else {}
+                error_message = data.get("message") or str(error)
 
-                usage = event.get("usage", {})
-                input_tokens = usage.get("input_tokens", 0) or 0
-                output_tokens = usage.get("output_tokens", 0) or 0
-                cache_read_tokens = usage.get("cache_read_input_tokens", 0) or 0
-                cache_write_tokens = usage.get("cache_creation_input_tokens", 0) or 0
-                if input_tokens or output_tokens:
-                    token_usage = TokenUsage(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=input_tokens + output_tokens,
-                        cache_read_tokens=cache_read_tokens,
-                        cache_write_tokens=cache_write_tokens,
-                    )
+        token_usage = None
+        if input_tokens or output_tokens:
+            token_usage = TokenUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            )
 
         return {
-            "response": response,
+            "response": "\n".join(response_parts),
             "error": error_message,
             "token_usage": token_usage,
             "model": model,
@@ -191,4 +204,4 @@ class ClaudeCodeSolver(BaseSolver):
 
 
 if __name__ == "__main__":
-    print(ClaudeCodeSolver(debug=True).solve_task())
+    print(OpenCodeSolver(debug=True).solve_task())

--- a/gamedevbench/src/pi_solver.py
+++ b/gamedevbench/src/pi_solver.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Claude Code CLI solver for GameDevBench tasks."""
+"""Pi coding agent CLI solver for GameDevBench tasks."""
 
 import json
 import os
@@ -13,21 +13,20 @@ from gamedevbench.src.utils.data_types import SolverResult, TokenUsage
 from gamedevbench.src.utils.processes import run_cli_command
 
 
-class ClaudeCodeSolver(BaseSolver):
-    """Run tasks through Claude Code while preserving its default prompt and tools."""
+class PiSolver(BaseSolver):
+    """Run tasks through Pi while preserving its default prompt, tools, and extensions."""
 
-    SUPPORTS_MCP = True
+    SUPPORTS_MCP = False
     SUPPORTS_SYSTEM_PROMPT = False
 
     def __init__(
         self,
         timeout_seconds: int = 600,
         debug: bool = False,
-        use_mcp: bool = False,
-        use_runtime_video: bool = False,
         model: Optional[str] = None,
+        use_runtime_video: bool = False,
     ):
-        super().__init__(timeout_seconds, debug, use_mcp, use_runtime_video)
+        super().__init__(timeout_seconds, debug, False, use_runtime_video)
         self.model = model
 
     @staticmethod
@@ -36,14 +35,11 @@ class ClaudeCodeSolver(BaseSolver):
         return any(
             keyword in error_lower
             for keyword in (
-                "overloaded",
                 "rate limit",
                 "rate_limit",
                 "quota exceeded",
                 "too many requests",
                 "429",
-                "capacity",
-                "usage limit",
             )
         )
 
@@ -52,36 +48,18 @@ class ClaudeCodeSolver(BaseSolver):
         if not config:
             return SolverResult(False, "Could not load task configuration", 0.0)
 
-        executable = shutil.which("claude")
+        prompt = self.get_task_prompt(config)
+        executable = shutil.which("pi")
         if not executable:
             return SolverResult(
                 False,
-                "Claude Code CLI not found. Install from: https://code.claude.com/",
+                "Pi CLI not found. Install from: https://github.com/badlogic/pi-mono",
                 0.0,
             )
 
-        prompt = self.get_task_prompt(config)
-        cmd = [
-            executable,
-            "--print",
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "--dangerously-skip-permissions",
-            "--no-session-persistence",
-        ]
+        cmd = [executable, "--mode", "json", "--print", "--no-session"]
         if self.model:
             cmd.extend(["--model", self.model])
-        if self.use_mcp:
-            mcp_config = {
-                "mcpServers": {
-                    "godot-screenshot": {
-                        "command": "uv",
-                        "args": ["run", "gamedevbench-mcp"],
-                    }
-                }
-            }
-            cmd.extend(["--mcp-config", json.dumps(mcp_config)])
         cmd.append(prompt)
 
         start_time = time.time()
@@ -90,12 +68,13 @@ class ClaudeCodeSolver(BaseSolver):
                 cmd,
                 timeout_seconds=self.timeout_seconds,
                 cwd=os.getcwd(),
+                env=self._command_environment(),
             )
             duration = time.time() - start_time
             parsed = self._parse_output(result.stdout)
             error_message = parsed["error"]
             success = result.returncode == 0 and not error_message
-            model_used = parsed["model"] or self.model or "claude-code-default"
+            model_used = parsed["model"] or self.model or "pi-default"
             token_usage = parsed["token_usage"]
             cost_usd = token_usage.calculate_cost(model_used) if token_usage else 0.0
 
@@ -103,13 +82,14 @@ class ClaudeCodeSolver(BaseSolver):
                 message = parsed["response"] or "Task completed"
             else:
                 details = error_message or result.stderr.strip()
-                message = f"Claude Code CLI failed (exit code {result.returncode})"
+                message = f"Pi CLI failed (exit code {result.returncode})"
                 if details:
                     message += f": {details}"
 
             combined_error = "\n".join(
                 part for part in (error_message, result.stderr) if part
             )
+
             if self.debug:
                 print(result.stdout)
                 if result.stderr:
@@ -129,30 +109,36 @@ class ClaudeCodeSolver(BaseSolver):
         except subprocess.TimeoutExpired:
             return SolverResult(
                 False,
-                f"Claude Code CLI timed out after {self.timeout_seconds}s",
+                f"Pi CLI timed out after {self.timeout_seconds}s",
                 time.time() - start_time,
             )
         except FileNotFoundError:
             return SolverResult(
                 False,
-                "Claude Code CLI not found. Install from: https://code.claude.com/",
+                "Pi CLI not found. Install from: https://github.com/badlogic/pi-mono",
                 0.0,
             )
         except Exception as exc:
             error_message = str(exc)
             return SolverResult(
                 False,
-                f"Error invoking Claude Code: {error_message}",
+                f"Error invoking Pi: {error_message}",
                 time.time() - start_time,
                 is_rate_limited=self.is_rate_limit_error(error_message),
             )
 
+    def _command_environment(self) -> Optional[dict[str, str]]:
+        return None
+
     @staticmethod
     def _parse_output(output: str) -> dict:
-        response = ""
-        error_message = ""
+        input_tokens = 0
+        output_tokens = 0
+        cache_read_tokens = 0
+        cache_write_tokens = 0
+        final_response = ""
         model = ""
-        token_usage = None
+        error_message = ""
 
         for line in output.splitlines():
             try:
@@ -160,30 +146,46 @@ class ClaudeCodeSolver(BaseSolver):
             except json.JSONDecodeError:
                 continue
 
-            if event.get("type") == "assistant":
-                message = event.get("message", {})
-                model = message.get("model") or model
-            elif event.get("type") == "result":
-                response = event.get("result") or response
-                if event.get("is_error") or event.get("subtype") != "success":
-                    error_message = response or event.get("subtype", "Claude Code error")
+            if event.get("type") == "error":
+                error_message = event.get("message") or str(event.get("error", event))
+                continue
+            if event.get("type") != "message_end":
+                continue
 
-                usage = event.get("usage", {})
-                input_tokens = usage.get("input_tokens", 0) or 0
-                output_tokens = usage.get("output_tokens", 0) or 0
-                cache_read_tokens = usage.get("cache_read_input_tokens", 0) or 0
-                cache_write_tokens = usage.get("cache_creation_input_tokens", 0) or 0
-                if input_tokens or output_tokens:
-                    token_usage = TokenUsage(
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=input_tokens + output_tokens,
-                        cache_read_tokens=cache_read_tokens,
-                        cache_write_tokens=cache_write_tokens,
-                    )
+            message = event.get("message", {})
+            if message.get("role") != "assistant":
+                continue
+
+            if message.get("stopReason") == "error":
+                error_message = message.get("errorMessage") or "Pi model request failed"
+
+            usage = message.get("usage", {})
+            input_tokens += usage.get("input", 0) or 0
+            output_tokens += usage.get("output", 0) or 0
+            cache_read_tokens += usage.get("cacheRead", 0) or 0
+            cache_write_tokens += usage.get("cacheWrite", 0) or 0
+            model = message.get("model") or model
+
+            text_parts = [
+                part.get("text", "")
+                for part in message.get("content", [])
+                if part.get("type") == "text"
+            ]
+            if text_parts:
+                final_response = "\n".join(text_parts)
+
+        token_usage = None
+        if input_tokens or output_tokens:
+            token_usage = TokenUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            )
 
         return {
-            "response": response,
+            "response": final_response,
             "error": error_message,
             "token_usage": token_usage,
             "model": model,
@@ -191,4 +193,4 @@ class ClaudeCodeSolver(BaseSolver):
 
 
 if __name__ == "__main__":
-    print(ClaudeCodeSolver(debug=True).solve_task())
+    print(PiSolver(debug=True).solve_task())

--- a/gamedevbench/src/pi_stock_solver.py
+++ b/gamedevbench/src/pi_stock_solver.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Pi solver using Pi's built-in system prompt in an isolated config directory."""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from gamedevbench.src.pi_solver import PiSolver
+from gamedevbench.src.utils.constants import PROJECT_ROOT
+from gamedevbench.src.utils.data_types import SolverResult
+
+
+DEFAULT_CONFIG_DIR = PROJECT_ROOT / ".benchmark-config" / "pi-stock"
+
+
+class PiStockSolver(PiSolver):
+    """Run Pi without a user SYSTEM.md while retaining its normal built-in tools."""
+
+    def solve_task(self) -> SolverResult:
+        config_dir = self._config_dir()
+        if not (config_dir / "settings.json").is_file():
+            return SolverResult(
+                False,
+                f"Pi stock config is not prepared: {config_dir}",
+                0.0,
+            )
+        if any((config_dir / name).exists() for name in ("SYSTEM.md", "system.md")):
+            return SolverResult(
+                False,
+                f"Pi stock config must not contain SYSTEM.md: {config_dir}",
+                0.0,
+            )
+        return super().solve_task()
+
+    def _config_dir(self) -> Path:
+        override = os.environ.get("GAMEDEVBENCH_PI_STOCK_CONFIG_DIR")
+        return Path(override) if override else DEFAULT_CONFIG_DIR
+
+    def _command_environment(self) -> Optional[dict[str, str]]:
+        env = os.environ.copy()
+        env["PI_CODING_AGENT_DIR"] = str(self._config_dir())
+        return env

--- a/gamedevbench/src/solver_factory.py
+++ b/gamedevbench/src/solver_factory.py
@@ -9,6 +9,10 @@ from gamedevbench.src.claude_code_solver import ClaudeCodeSolver
 from gamedevbench.src.mini_swe_solver import MiniSweSolver
 from gamedevbench.src.codex_solver import CodexSolver
 from gamedevbench.src.gemini_solver import GeminiSolver
+from gamedevbench.src.opencode_solver import OpenCodeSolver
+from gamedevbench.src.omo_solver import OmoSolver
+from gamedevbench.src.pi_solver import PiSolver
+from gamedevbench.src.pi_stock_solver import PiStockSolver
 
 # OpenHands requires Python 3.12+, make it optional
 try:
@@ -28,6 +32,10 @@ class SolverFactory:
         "mini-swe": MiniSweSolver,
         "codex": CodexSolver,
         "gemini-cli": GeminiSolver,
+        "opencode": OpenCodeSolver,
+        "omo": OmoSolver,
+        "pi": PiSolver,
+        "pi-stock": PiStockSolver,
     }
 
     # Conditionally add OpenHands if available
@@ -93,7 +101,7 @@ class SolverFactory:
         }
 
         # Add model parameter for solvers that support it
-        if agent in ["claude-code", "mini-swe", "openhands", "gemini-cli", "codex"]:
+        if agent in ["claude-code", "mini-swe", "openhands", "gemini-cli", "codex", "opencode", "omo", "pi", "pi-stock"]:
             if model:
                 kwargs["model"] = model
 

--- a/gamedevbench/src/utils/constants.py
+++ b/gamedevbench/src/utils/constants.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 from pathlib import Path
 
 # Directory paths
@@ -9,7 +10,7 @@ GT_TASKS_DIR = PROJECT_ROOT / "tasks_gt"
 RESULTS_FOLDER = PROJECT_ROOT / "results"
 
 # Godot configuration
-GODOT_EXEC_PATH = "godot"
+GODOT_EXEC_PATH = os.environ.get("GODOT_EXEC_PATH", "godot")
 GODOT_PROJECT_NAME = "project.godot"
 TEST_SCENE_NAME = "res://scenes/test.tscn"
 

--- a/gamedevbench/src/utils/data_types.py
+++ b/gamedevbench/src/utils/data_types.py
@@ -5,8 +5,21 @@ from datetime import datetime
 from typing import Dict, Optional
 
 
-# Token pricing per 1M tokens (USD) - Updated December 2024
+# Token pricing per 1M tokens (USD).
 TOKEN_PRICING = {
+    # DeepSeek via OpenCode Go
+    "deepseek-v4-flash": {
+        "input": 0.14,
+        "output": 0.28,
+        "cache_read": 0.0028,
+        "cache_write": 0.0,
+    },
+    "deepseek-v4-pro": {
+        "input": 1.74,
+        "output": 3.48,
+        "cache_read": 0.0145,
+        "cache_write": 0.0,
+    },
     # Anthropic Claude
     "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
     "claude-3-5-sonnet": {"input": 3.00, "output": 15.00},
@@ -44,15 +57,21 @@ class TokenUsage:
         model_lower = model.lower()
         pricing = TOKEN_PRICING.get("default")
 
-        for key in TOKEN_PRICING:
+        for key in sorted(TOKEN_PRICING, key=len, reverse=True):
             if key in model_lower:
                 pricing = TOKEN_PRICING[key]
                 break
 
         input_cost = (self.input_tokens / 1_000_000) * pricing["input"]
         output_cost = (self.output_tokens / 1_000_000) * pricing["output"]
+        cache_read_cost = (self.cache_read_tokens / 1_000_000) * pricing.get(
+            "cache_read", 0.0
+        )
+        cache_write_cost = (self.cache_write_tokens / 1_000_000) * pricing.get(
+            "cache_write", 0.0
+        )
 
-        return input_cost + output_cost
+        return input_cost + output_cost + cache_read_cost + cache_write_cost
 
     def to_dict(self) -> Dict:
         return {

--- a/gamedevbench/src/utils/environment.py
+++ b/gamedevbench/src/utils/environment.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Capture reproducibility metadata for benchmark runs."""
+
+import platform
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from gamedevbench.src.utils.constants import GODOT_EXEC_PATH, PROJECT_ROOT
+
+
+AGENT_VERSION_COMMANDS = {
+    "claude-code": ["claude", "--version"],
+    "opencode": ["opencode", "--version"],
+    "omo": ["opencode", "--version"],
+    "pi": ["pi", "--version"],
+    "pi-stock": ["pi", "--version"],
+    "codex": ["codex", "--version"],
+    "gemini-cli": ["gemini", "--version"],
+    "mini-swe": ["mini-swe-agent-mcp", "--version"],
+}
+
+
+def collect_environment_metadata(
+    agent: Optional[str],
+    capture_source: str = "runtime",
+) -> dict:
+    """Collect tool and repository versions once at benchmark startup."""
+    agent_command = AGENT_VERSION_COMMANDS.get(agent)
+    metadata = {
+        "captured_at": datetime.now().isoformat(),
+        "capture_source": capture_source,
+        "agent_cli": {
+            "name": agent,
+            "version": _command_version(agent_command),
+        },
+        "godot": {
+            "executable": GODOT_EXEC_PATH,
+            "version": _command_version([GODOT_EXEC_PATH, "--version"]),
+        },
+        "python": {
+            "version": platform.python_version(),
+            "executable": sys.executable,
+        },
+        "platform": platform.platform(),
+        "gamedevbench": _git_metadata(PROJECT_ROOT),
+    }
+    variant = _variant_metadata(agent)
+    if variant:
+        metadata["variant"] = variant
+    return metadata
+
+
+def _variant_metadata(agent: Optional[str]) -> Optional[dict]:
+    if agent == "pi-stock":
+        config_dir = Path(
+            os.environ.get(
+                "GAMEDEVBENCH_PI_STOCK_CONFIG_DIR",
+                PROJECT_ROOT / ".benchmark-config" / "pi-stock",
+            )
+        )
+        return {
+            "name": "pi-stock",
+            "config_dir": str(config_dir),
+            "system_prompt": "built-in",
+            "system_md_present": any(
+                (config_dir / name).exists() for name in ("SYSTEM.md", "system.md")
+            ),
+            "settings_sha256": _file_sha256(config_dir / "settings.json"),
+            "models_sha256": _file_sha256(config_dir / "models.json"),
+        }
+    if agent == "omo":
+        xdg_home = Path(
+            os.environ.get(
+                "GAMEDEVBENCH_OMO_XDG_CONFIG_HOME",
+                PROJECT_ROOT / ".benchmark-config" / "omo",
+            )
+        )
+        config_dir = xdg_home / "opencode"
+        package_json = config_dir / "node_modules" / "oh-my-openagent" / "package.json"
+        return {
+            "name": "omo",
+            "primary_agent": "Sisyphus - ultraworker",
+            "xdg_config_home": str(xdg_home),
+            "opencode_config_sha256": _file_sha256(config_dir / "opencode.json"),
+            "omo_config_sha256": _first_file_sha256(
+                config_dir,
+                ("oh-my-openagent.jsonc", "oh-my-opencode.jsonc"),
+            ),
+            "omo_version": _package_version(package_json)
+            or _text_value(config_dir / "benchmark-omo-version.txt"),
+        }
+    return None
+
+
+def _file_sha256(path: Path) -> Optional[str]:
+    if not path.is_file():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _first_file_sha256(directory: Path, names: tuple[str, ...]) -> Optional[str]:
+    for name in names:
+        value = _file_sha256(directory / name)
+        if value:
+            return value
+    return None
+
+
+def _package_version(path: Path) -> Optional[str]:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8")).get("version")
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _text_value(path: Path) -> Optional[str]:
+    if not path.is_file():
+        return None
+    value = path.read_text(encoding="utf-8-sig").strip()
+    return value or None
+
+
+def _command_version(command: Optional[list[str]]) -> Optional[str]:
+    if not command:
+        return None
+
+    executable = command[0]
+    resolved = shutil.which(executable) if not Path(executable).is_file() else executable
+    if not resolved:
+        return None
+
+    try:
+        result = subprocess.run(
+            [resolved, *command[1:]],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    output = (result.stdout or result.stderr).strip()
+    return output.splitlines()[0] if output else None
+
+
+def _git_metadata(repo: Path) -> dict:
+    return {
+        "commit": _git_value(repo, "rev-parse", "HEAD"),
+        "branch": _git_value(repo, "branch", "--show-current"),
+        "dirty": bool(_git_value(repo, "status", "--porcelain")),
+    }
+
+
+def _git_value(repo: Path, *args: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    value = result.stdout.strip()
+    return value or None

--- a/gamedevbench/src/utils/processes.py
+++ b/gamedevbench/src/utils/processes.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Subprocess helpers for CLI-based benchmark solvers."""
+
+import os
+import signal
+import subprocess
+from typing import Mapping, Optional, Sequence
+
+
+def run_cli_command(
+    command: Sequence[str],
+    timeout_seconds: int,
+    cwd: str,
+    env: Optional[Mapping[str, str]] = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a CLI command and kill its full process tree on timeout."""
+    creationflags = 0
+    start_new_session = False
+    if os.name == "nt":
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        start_new_session = True
+
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        creationflags=creationflags,
+        start_new_session=start_new_session,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        _kill_process_tree(process)
+        stdout, stderr = process.communicate()
+        raise subprocess.TimeoutExpired(
+            command,
+            timeout_seconds,
+            output=stdout or exc.output,
+            stderr=stderr or exc.stderr,
+        ) from exc
+
+    return subprocess.CompletedProcess(
+        command,
+        process.returncode,
+        stdout,
+        stderr,
+    )
+
+
+def _kill_process_tree(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+        )
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass

--- a/gamedevbench/src/utils/prompts.py
+++ b/gamedevbench/src/utils/prompts.py
@@ -9,6 +9,8 @@ ensuring consistency across different agents.
 import json
 from typing import Optional
 
+from gamedevbench.src.utils.constants import GODOT_EXEC_PATH
+
 
 def load_task_config() -> Optional[dict]:
     """Load task configuration from task_config.json in current directory.
@@ -17,7 +19,7 @@ def load_task_config() -> Optional[dict]:
         Parsed task configuration dict, or None if loading fails
     """
     try:
-        with open("task_config.json", "r") as f:
+        with open("task_config.json", "r", encoding="utf-8") as f:
             return json.load(f)
     except Exception as e:
         print(f"Error loading config: {e}")
@@ -44,18 +46,18 @@ def create_task_prompt(config: dict, use_runtime_video: bool = False, use_mcp: b
     instruction = config.get("instruction")
     
     instruction += "\n You must complete the full task without any further assistance."
-    instruction += "\n Godot is installed and you can run godot using the `godot` command. It is recommended to run this with a timeout (e.g., `timeout 10 godot` for 10 second timeout) to prevent hanging."
+    instruction += f"\n Godot is installed at `{GODOT_EXEC_PATH}`. Use that exact executable path when running Godot and always set a timeout to prevent hanging."
     instruction += "You are a visual agent and can use images and videos to help you understand the state of the game."
 
     if use_runtime_video:
         runtime_guidance = """
-    - You can run the game and get an image with `godot --path . --quit-after 1
+    - You can run the game and get an image with `"{godot_exec}" --path . --quit-after 1
     --write-movie output.png`.
-    - You can save a movie file as avi instead with `timeout 60s godot --path . --quit-after 60 --write-movie output.avi`. This is a 1 second or 60 frame video. You can adjust as necessary.
+    - You can save a movie file as avi instead with `"{godot_exec}" --path . --quit-after 60 --write-movie output.avi`. This is a 1 second or 60 frame video. You can adjust as necessary.
     - It is very important that you ensure godot closes after running, or else the task will hang indefinitely.
     - You should use the video or images to verify that your changes worked as expected.
     """
-        instruction += runtime_guidance
+        instruction += runtime_guidance.format(godot_exec=GODOT_EXEC_PATH)
 
     if use_mcp:
         mcp_guidance = """

--- a/gamedevbench/src/utils/validation.py
+++ b/gamedevbench/src/utils/validation.py
@@ -76,7 +76,7 @@ class ValidationParser:
         filepath = results_dir / filename
         
         # Save result to JSON
-        with open(filepath, 'w') as f:
+        with open(filepath, 'w', encoding='utf-8') as f:
             json.dump(result.to_dict(), f, indent=2)
         
         print(f"Validation result saved to: {filepath}")

--- a/prepare_benchmark_variants.ps1
+++ b/prepare_benchmark_variants.ps1
@@ -1,0 +1,59 @@
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+
+$repo = Split-Path -Parent $MyInvocation.MyCommand.Path
+$variantRoot = Join-Path $repo ".benchmark-config"
+
+$piSource = Join-Path $HOME ".pi\agent"
+$piTarget = Join-Path $variantRoot "pi-stock"
+New-Item -ItemType Directory -Force -Path $piTarget | Out-Null
+foreach ($name in @("auth.json", "models.json", "settings.json")) {
+    $source = Join-Path $piSource $name
+    if (-not (Test-Path -LiteralPath $source)) {
+        throw "Missing Pi configuration file: $source"
+    }
+    Copy-Item -LiteralPath $source -Destination (Join-Path $piTarget $name) -Force
+}
+foreach ($name in @("SYSTEM.md", "system.md")) {
+    $path = Join-Path $piTarget $name
+    if (Test-Path -LiteralPath $path) {
+        Remove-Item -LiteralPath $path -Force
+    }
+}
+
+$omoXdg = Join-Path $variantRoot "omo"
+$omoConfig = Join-Path $omoXdg "opencode"
+New-Item -ItemType Directory -Force -Path $omoConfig | Out-Null
+
+$oldXdg = $env:XDG_CONFIG_HOME
+$oldConfigDir = $env:OPENCODE_CONFIG_DIR
+try {
+    $env:XDG_CONFIG_HOME = $omoXdg
+    $env:OPENCODE_CONFIG_DIR = $omoConfig
+    & npx -y oh-my-openagent@4.10.0 install --no-tui --platform=opencode --claude=no --openai=no --gemini=no --copilot=no --opencode-zen=no --zai-coding-plan=no --opencode-go=yes --kimi-for-coding=no --vercel-ai-gateway=no --skip-auth
+    if ($LASTEXITCODE -ne 0) {
+        throw "OMO installer failed with exit code $LASTEXITCODE"
+    }
+} finally {
+    $env:XDG_CONFIG_HOME = $oldXdg
+    $env:OPENCODE_CONFIG_DIR = $oldConfigDir
+}
+
+$template = Join-Path $repo "benchmark_configs\omo_deepseek_v4_flash.jsonc"
+$opencodeTemplate = Join-Path $repo "benchmark_configs\omo_opencode.json"
+foreach ($name in @(
+    "oh-my-openagent.json",
+    "oh-my-opencode.json",
+    "oh-my-opencode.jsonc"
+)) {
+    $path = Join-Path $omoConfig $name
+    if (Test-Path -LiteralPath $path) {
+        Remove-Item -LiteralPath $path -Force
+    }
+}
+Copy-Item -LiteralPath $template -Destination (Join-Path $omoConfig "oh-my-openagent.jsonc") -Force
+Copy-Item -LiteralPath $opencodeTemplate -Destination (Join-Path $omoConfig "opencode.json") -Force
+Set-Content -LiteralPath (Join-Path $omoConfig "benchmark-omo-version.txt") -Value "4.10.0" -Encoding utf8
+
+Write-Host "Prepared Pi stock config: $piTarget"
+Write-Host "Prepared isolated OMO config: $omoConfig"

--- a/run_benchmark_variants.ps1
+++ b/run_benchmark_variants.ps1
@@ -1,0 +1,45 @@
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
+
+$repo = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repo
+
+if (-not $env:GODOT_EXEC_PATH) {
+    $env:GODOT_EXEC_PATH = "godot"
+}
+$env:PYTHONUNBUFFERED = "1"
+$env:PYTHONIOENCODING = "utf-8"
+
+$logDir = Join-Path $repo "results\benchmark_variant_logs"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+function Run-Agent {
+    param(
+        [string]$Name,
+        [string[]]$Arguments
+    )
+
+    $log = Join-Path $logDir "$Name.log"
+    "[$(Get-Date -Format o)] Starting $Name" | Tee-Object -FilePath $log -Append
+    & python -m gamedevbench.src.benchmark_runner @Arguments 2>&1 |
+        Tee-Object -FilePath $log -Append
+    $exitCode = $LASTEXITCODE
+    "[$(Get-Date -Format o)] Finished $Name with exit code $exitCode" |
+        Tee-Object -FilePath $log -Append
+    if ($exitCode -ne 0) {
+        throw "$Name benchmark failed with exit code $exitCode"
+    }
+}
+
+Run-Agent "pi-stock" @(
+    "--agent", "pi-stock",
+    "--model", "deepseek/deepseek-v4-flash",
+    "run", "--task-list", "benchmark_24.yaml"
+)
+
+Run-Agent "omo" @(
+    "--agent", "omo",
+    "--model", "opencode-go/deepseek-v4-flash",
+    "run", "--task-list", "benchmark_24.yaml"
+)

--- a/tests/test_cli_solvers.py
+++ b/tests/test_cli_solvers.py
@@ -1,0 +1,284 @@
+import json
+
+import pytest
+
+from gamedevbench.src.claude_code_solver import ClaudeCodeSolver
+from gamedevbench.src.benchmark_runner import (
+    MAX_TRAJECTORY_STREAM_CHARS,
+    _write_solver_trajectory,
+)
+from gamedevbench.src.opencode_solver import OpenCodeSolver
+from gamedevbench.src.omo_solver import OmoSolver
+from gamedevbench.src.pi_solver import PiSolver
+from gamedevbench.src.pi_stock_solver import PiStockSolver
+from gamedevbench.src.utils.data_types import SolverResult, TokenUsage
+from gamedevbench.src.utils.environment import collect_environment_metadata
+
+
+def test_solver_trajectory_is_written_as_utf8(tmp_path):
+    result = SolverResult(
+        success=True,
+        message="完成 ✓",
+        duration_seconds=1.0,
+        stdout='{"text":"中文 ✓"}',
+        stderr="警告 ✓",
+    )
+    path = tmp_path / "agent_trajectory.log"
+
+    _write_solver_trajectory(
+        path,
+        "task_utf8",
+        "pi",
+        "deepseek-v4-flash",
+        tmp_path,
+        result,
+    )
+
+    content = path.read_bytes().decode("utf-8")
+    assert "完成 ✓" in content
+    assert "中文 ✓" in content
+    assert "警告 ✓" in content
+
+
+def test_solver_trajectory_truncates_oversized_streams(tmp_path):
+    stdout = "START✓" + ("中" * MAX_TRAJECTORY_STREAM_CHARS) + "END✓"
+    result = SolverResult(
+        success=True,
+        message="done",
+        duration_seconds=1.0,
+        stdout=stdout,
+    )
+    path = tmp_path / "agent_trajectory.log"
+
+    _write_solver_trajectory(
+        path,
+        "task_large",
+        "pi",
+        "deepseek-v4-flash",
+        tmp_path,
+        result,
+    )
+
+    content = path.read_text(encoding="utf-8")
+    assert "START✓" in content
+    assert "END✓" in content
+    assert "omitted" in content
+    assert path.stat().st_size < 16_000_000
+
+
+def test_environment_metadata_records_versions(monkeypatch):
+    monkeypatch.setattr(
+        "gamedevbench.src.utils.environment._command_version",
+        lambda command: "test-version" if command else None,
+    )
+    monkeypatch.setattr(
+        "gamedevbench.src.utils.environment._git_metadata",
+        lambda repo: {"commit": "abc", "branch": "test", "dirty": False},
+    )
+
+    metadata = collect_environment_metadata("pi")
+
+    assert metadata["capture_source"] == "runtime"
+    assert metadata["agent_cli"] == {"name": "pi", "version": "test-version"}
+    assert metadata["godot"]["version"] == "test-version"
+    assert metadata["gamedevbench"]["commit"] == "abc"
+
+
+def test_pi_stock_uses_isolated_config_without_system_prompt(tmp_path, monkeypatch):
+    (tmp_path / "settings.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("GAMEDEVBENCH_PI_STOCK_CONFIG_DIR", str(tmp_path))
+
+    solver = PiStockSolver(model="deepseek/deepseek-v4-flash")
+    env = solver._command_environment()
+
+    assert env["PI_CODING_AGENT_DIR"] == str(tmp_path)
+    assert not (tmp_path / "SYSTEM.md").exists()
+
+
+def test_omo_uses_sisyphus_and_isolated_opencode_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAMEDEVBENCH_OMO_XDG_CONFIG_HOME", str(tmp_path))
+
+    solver = OmoSolver(model="opencode-go/deepseek-v4-flash")
+    env = solver._command_environment()
+
+    assert solver._agent_name() == "Sisyphus - ultraworker"
+    assert env["XDG_CONFIG_HOME"] == str(tmp_path)
+    assert env["OPENCODE_CONFIG_DIR"] == str(tmp_path / "opencode")
+    assert env["OMO_SEND_ANONYMOUS_TELEMETRY"] == "0"
+    assert env["OPENCODE_DISABLE_CLAUDE_CODE_SKILLS"] == "true"
+
+
+def test_omo_extracts_subagent_session_and_exported_usage():
+    output = json.dumps(
+        {
+            "type": "tool_use",
+            "part": {
+                "tool": "task",
+                "state": {"metadata": {"sessionId": "ses_child"}},
+            },
+        }
+    )
+    exported = json.dumps(
+        {
+            "info": {
+                "tokens": {
+                    "input": 100,
+                    "output": 20,
+                    "reasoning": 5,
+                    "cache": {"read": 40, "write": 2},
+                }
+            }
+        }
+    )
+
+    assert OmoSolver._subagent_session_ids(output) == {"ses_child"}
+    usage = OmoSolver._parse_exported_usage(exported)
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 25
+    assert usage.total_tokens == 125
+    assert usage.cache_read_tokens == 40
+    assert usage.cache_write_tokens == 2
+
+
+def test_claude_code_parses_result_usage_cost_and_actual_model():
+    output = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"model": "deepseek-v4-flash"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "done",
+                    "total_cost_usd": 99.0,
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "cache_read_input_tokens": 40,
+                        "cache_creation_input_tokens": 5,
+                    },
+                }
+            ),
+        ]
+    )
+
+    parsed = ClaudeCodeSolver._parse_output(output)
+
+    assert parsed["response"] == "done"
+    assert parsed["model"] == "deepseek-v4-flash"
+    assert parsed["token_usage"].input_tokens == 100
+    assert parsed["token_usage"].output_tokens == 20
+    assert parsed["token_usage"].cache_read_tokens == 40
+    assert parsed["token_usage"].cache_write_tokens == 5
+
+
+def test_opencode_parses_usage_response_and_reasoning_tokens():
+    output = "\n".join(
+        [
+            json.dumps({"type": "text", "part": {"text": "done"}}),
+            json.dumps(
+                {
+                    "type": "step_finish",
+                    "part": {
+                        "tokens": {
+                            "input": 100,
+                            "output": 20,
+                            "reasoning": 30,
+                            "cache": {"read": 40, "write": 5},
+                        },
+                        "cost": 99.0,
+                    },
+                }
+            ),
+        ]
+    )
+
+    parsed = OpenCodeSolver._parse_output(output)
+
+    assert parsed["response"] == "done"
+    assert parsed["token_usage"].input_tokens == 100
+    assert parsed["token_usage"].output_tokens == 50
+    assert parsed["token_usage"].total_tokens == 150
+    assert parsed["token_usage"].cache_read_tokens == 40
+    assert parsed["token_usage"].cache_write_tokens == 5
+
+
+def test_opencode_treats_json_error_as_failure_detail():
+    output = json.dumps(
+        {
+            "type": "error",
+            "error": {"data": {"message": "rate limit exceeded"}},
+        }
+    )
+
+    parsed = OpenCodeSolver._parse_output(output)
+
+    assert parsed["error"] == "rate limit exceeded"
+
+
+def test_pi_sums_assistant_turn_usage_and_uses_last_response():
+    def assistant_message(text, input_tokens, output_tokens, cost):
+        return json.dumps(
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": text}],
+                    "model": "deepseek-v4-flash",
+                    "usage": {
+                        "input": input_tokens,
+                        "output": output_tokens,
+                        "cacheRead": 10,
+                        "cacheWrite": 2,
+                        "cost": {"total": cost},
+                    },
+                    "stopReason": "stop",
+                },
+            }
+        )
+
+    output = "\n".join(
+        [
+            assistant_message("working", 100, 20, 0.01),
+            assistant_message("done", 200, 30, 0.02),
+        ]
+    )
+
+    parsed = PiSolver._parse_output(output)
+
+    assert parsed["response"] == "done"
+    assert parsed["model"] == "deepseek-v4-flash"
+    assert parsed["token_usage"].input_tokens == 300
+    assert parsed["token_usage"].output_tokens == 50
+    assert parsed["token_usage"].total_tokens == 350
+    assert parsed["token_usage"].cache_read_tokens == 20
+    assert parsed["token_usage"].cache_write_tokens == 4
+
+
+def test_deepseek_v4_flash_cost_uses_opencode_go_token_pricing():
+    usage = TokenUsage(
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=1_000_000,
+        cache_write_tokens=1_000_000,
+    )
+
+    assert usage.calculate_cost("opencode-go/deepseek-v4-flash") == pytest.approx(
+        0.4228
+    )
+
+
+def test_deepseek_v4_pro_cost_uses_opencode_go_token_pricing():
+    usage = TokenUsage(
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+        cache_read_tokens=1_000_000,
+        cache_write_tokens=1_000_000,
+    )
+
+    assert usage.calculate_cost("deepseek-v4-pro") == pytest.approx(5.2345)


### PR DESCRIPTION
## Summary

This PR adds local benchmark harness support and documentation for additional coding-agent CLIs used in a 24-task GameDevBench comparison.

- adds OpenCode, Pi, Pi-stock, and OMO solver integrations
- adds UTF-8-safe CLI subprocess handling, bounded trajectory logs, and environment metadata capture
- adds token/cost parsing for Claude Code, OpenCode/OMO, Pi, and Codex-style JSON output
- adds a fixed `benchmark_24.yaml` subset and isolated OMO/Pi variant preparation scripts
- documents the local 24-task comparison in README with model routing, reasoning effort, pass rates, token counts, costs, and caveats
- adds focused parser/environment tests for the new CLI harness behavior

## Local benchmark summary documented in README

| Run | Agent / Harness | Passed | Success rate |
| --- | --- | ---: | ---: |
| DeepSeek V4 Pro practical | Claude Code | 11 / 24 | 45.83% |
| DeepSeek V4 Pro practical | OpenCode | 8 / 24 | 33.33% |
| DeepSeek V4 Pro practical | Pi | 9 / 24 | 37.50% |
| DeepSeek V4 Pro practical | Pi stock | 7 / 24 | 29.17% |
| DeepSeek V4 Pro practical | OMO | 6 / 24 | 25.00% |
| Codex default baseline | Codex | 14 / 24 | 58.33% |
| Pi GLM-5.2 | Pi | 8 / 24 | 33.33% |
| Pi Qwen3.7 Max | Pi | 11 / 24 | 45.83% |

## Validation

- `PYTHONPATH=. pytest tests/test_cli_solvers.py` -> 12 passed

## Notes

- Local result JSON/log directories are intentionally not committed.
- One-off local run scripts and local machine paths were intentionally left out of the commit.
- README labels these as local comparison runs, not upstream leaderboard results.